### PR TITLE
adds callback to reply event

### DIFF
--- a/humock.coffee
+++ b/humock.coffee
@@ -21,6 +21,7 @@ addScriptsWhichAreBeingTested = (scripts) ->
 
 testWithCallback = (message, callback) ->
   adapter.on 'send', callback
+  adapter.on 'reply', callback
   adapter.receive new TextMessage(user, message)
 
 testWithPromise = (message) ->


### PR DESCRIPTION
As it seems, the `testWithCallback` method only hooks into the `send` event in the mock adapter. This won't work when in the cases when hubot needs to be addressed directly, e.g. 

```
hubot: help me with my laundry 
```

This PR should add the additional hook in the adapter.
