### PR TITLE
adds grunt-cli locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chai": "^1.10.0",
     "coffee-script": "^1.6.3",
     "grunt": "^0.4.5",
+    "grunt-cli": "^1.1.0",
     "grunt-contrib-watch": "^0.5.3",
     "grunt-mocha-test": "^0.7.0",
     "grunt-release": "^0.6.1",


### PR DESCRIPTION
This PR installs `grunt-cli` as a local dependency in the package, putting it implicitly on `npm`s PATH. 

This will make the packages node scripts executable without having `grunt-cli` installed globally, which is something not everybody wants to do.
