### PR TITLE
An attempt in avoiding internal code duplication

### DIFF
--- a/humock.coffee
+++ b/humock.coffee
@@ -20,19 +20,19 @@ addScriptsWhichAreBeingTested = (scripts) ->
     addScript scripts
 
 testWithCallback = (message, callback) ->
-  adapter.on 'send', callback
-  adapter.on 'reply', callback
+  [ 'send', 'reply' ].forEach (event) ->
+    adapter.on event, callback
   adapter.receive new TextMessage(user, message)
+
 
 testWithPromise = (message) ->
   Q.Promise (resolve) ->
-    adapter.on 'send', (envelope, strings) ->
+    testWithCallback message, (envelope, strings) ->
       resolve {
         envelope,
         strings,
         toString: -> strings[0]
       }
-    adapter.receive new TextMessage(user, message)
 
 module.exports =
   getUser: -> user

--- a/test/hello-script.coffee
+++ b/test/hello-script.coffee
@@ -1,3 +1,5 @@
 module.exports = (robot) ->
   robot.hear /hello/, (msg) ->
       msg.send 'hello back'
+  robot.respond /foo/, (msg) ->
+      msg.reply 'bar'

--- a/test/humock-test.coffee
+++ b/test/humock-test.coffee
@@ -44,14 +44,24 @@ describe 'humock', ->
     afterEach (done) ->
       humock.shutdown -> done()
 
-    it 'provides callback-based way of testing', (done) ->
+    it 'provides callback-based way of testing send', (done) ->
       humock.test 'hello', (envelope, strings) ->
         expect(strings[0]).match /hello back/
         done()
 
-    it 'provides promise-based way of testing', (done) ->
+    it 'provides promise-based way of testing send', (done) ->
       humock.test('hello').then (response) ->
         expect(response.toString()).match /hello back/
+        done()
+
+    it 'provides callback-based way of testing reply', (done) ->
+      humock.test 'hubot: foo', (envelope, strings) ->
+        expect(strings[0]).match /bar/
+        done()
+
+    it 'provides promise-based way of testing reply', (done) ->
+      humock.test('hubot: foo').then (response) ->
+        expect(response.toString()).match /bar/
         done()
 
   describe 'shutdown', ->


### PR DESCRIPTION
Hi Herman, taking you up on your [comment](https://github.com/Hermanya/mock-hubot/pull/2#issuecomment-202495213), this might be a way to keep both ways in sync: effectively calling the "by callback" piece from the promise. WDYT?
